### PR TITLE
Update python submodule to v0.2.0 and make changes to navbar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,7 +2,24 @@
 <ul id="mysidebar" class="nav">
     <li class="sidebarTitle">Navigation</li>
     {% for folder in folders %}
-    {% if folder.name != "" %}
+    {% if folder.name != "" and folder.name != "News" and folder.name != "Tags" %}
+    <li class="deactive">
+        <a href="#">{{ folder.name }}</a>
+        <ul>
+            {% assign other_pages = folder.items | sort: 'is_landingpage' | reverse %}
+            {% for other_page in other_pages %}
+            {% if other_page.url == page.url %}
+            <li class="active"><a href="{{ other_page.url }}" >{{ other_page.title }}</a></li>
+            {% else %}
+            <li><a href="{{ other_page.url }}" >{{ other_page.title }}</a></li>
+            {% endif %}
+            {% endfor %}
+        </ul>
+    </li>
+    {% endif %}
+    {% endfor %}
+    {% for folder in folders %}
+    {% if folder.name != "" and folder.name == "News" or folder.name == "Tags" %}
     <li class="deactive">
         <a href="#">{{ folder.name }}</a>
         <ul>


### PR DESCRIPTION
Updates the python-cryptography submodule to current version v0.2.0.
Changes the nav bar on the left to first show all folders in `pages` that are neither News nor Tags and then News and Tags. Doing this puts news and tags at the bottom of the navigator.